### PR TITLE
Avoid using `for ( .. in .. )` to iterate over arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,11 @@ export function toTextPosition(root, selector, options = {}) {
 
   // Create a fold function that will reduce slices to positional extents.
   let foldSlices = (acc, slice) => {
+    if (!acc) {
+      // A search for an earlier slice of the pattern failed to match.
+      return null
+    }
+
     let result = dmp.match_main(root.textContent, slice, acc.loc)
     if (result === -1) {
       return null
@@ -144,13 +149,7 @@ export function toTextPosition(root, selector, options = {}) {
   // Expect the slices to be close to one another.
   // This distance is deliberately generous for now.
   dmp.Match_Distance = 64
-  const acc = slices.reduce((acc, slice) => {
-    if (!acc) {
-      return null
-    }
-    return foldSlices(acc, slice)
-  }, {start, end, loc});
-
+  const acc = slices.reduce(foldSlices, {start, end, loc})
   if (!acc) {
     return null
   }

--- a/src/index.js
+++ b/src/index.js
@@ -144,13 +144,15 @@ export function toTextPosition(root, selector, options = {}) {
   // Expect the slices to be close to one another.
   // This distance is deliberately generous for now.
   dmp.Match_Distance = 64
-  let acc = {start, end, loc}
-
-  for (let i in slices) {
-    acc = foldSlices(acc, slices[i])
-    if (acc === null) {
+  const acc = slices.reduce((acc, slice) => {
+    if (!acc) {
       return null
     }
+    return foldSlices(acc, slice)
+  }, {start, end, loc});
+
+  if (!acc) {
+    return null
   }
 
   return {start: acc.start, end: acc.end}

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -160,7 +160,7 @@ describe('textQuote', () => {
       assert.isNull(range)
     })
 
-    it('throws an error when a long quote is not found', () => {
+    it('returns null when a long quote is not found', () => {
       let exact = 'Quisque sit amet est et sapien ullam triceracorn'
       let range = toRange(fixture.el, {exact})
       assert.isNull(range)

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -1,6 +1,10 @@
 import {fromRange, toRange} from '../src'
 import {fromTextPosition, toTextPosition} from '../src'
 
+function simplify(str) {
+  return str.replace(/\s+/g, ' ')
+}
+
 describe('textQuote', () => {
   before(() => {
     fixture.setBase('test/fixtures')
@@ -161,9 +165,25 @@ describe('textQuote', () => {
     })
 
     it('returns null when a long quote is not found', () => {
-      let exact = 'Quisque sit amet est et sapien ullam triceracorn'
-      let range = toRange(fixture.el, {exact})
-      assert.isNull(range)
+      let exact = [
+        // Long quote whose first 32 chars match, but whose remainder does not
+        'Quisque sit amet est et sapien ullam triceracorn',
+
+        // Long quote where no part matches
+        'This is a long quote which does not match any part of the text',
+
+        // Long quote where the start and end match but a chunk in the middle
+        // does not
+        simplify(`Pellentesque habitant morbi tristique senectus et netus et
+            malesuada fames ac turpis egestas. *** DOES NOT MATCH*** tortor
+            quam, feugiat vitae, ultricies eget, *** DOES NOT MATCH ***. Donec
+            eu libero sit amet quam egestas semper.`)
+      ];
+
+      exact.forEach((exact) => {
+        let range = toRange(fixture.el, {exact})
+        assert.isNull(range)
+      });
     })
 
     it('uses a hint option to prioritize matches', () => {


### PR DESCRIPTION
for .. in loops iterate over all enumerable properties of an object,
including those on the prototype. This means that if the code runs in an
environment where Array.prototype contains enumerable properties, it
will loop over those too.

Use Array.prototype.reduce instead as a natural companion to a fold
function.

For context, see https://github.com/hypothesis/product-backlog/issues/143