### PR TITLE
Anchoring bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "eslint src && BABEL_ENV=test karma start --single-run",
+    "test:watch": "eslint src && BABEL_ENV=test karma start",
     "prepublish": "babel -d lib src"
   },
   "repository": {

--- a/test/bug_spec.js
+++ b/test/bug_spec.js
@@ -1,0 +1,22 @@
+import {fromRange, toRange} from '../src'
+import {fromTextPosition, toTextPosition} from '../src'
+
+describe('bug', () => {
+  before(() => {
+    fixture.setBase('test/fixtures')
+  })
+
+  beforeEach(() => {
+    fixture.load('bug.html')
+  })
+
+  afterEach(() => {
+    fixture.cleanup()
+  })
+
+  it('should anchor this quote correctly', () => {
+    let range = toRange(fixture.el, {"exact":"“A really important tree is about to hit the ground,” Mayor Bloomberg declared in St. Nicholas Park on Tuesday morning, before he lifted a shovel and planted an 11-year-old pin oak on a patch of lawn. He was helped by Representative Charles B. Rangel and other elected officials, as well as Carmelo Anthony, the Brooklyn-born basketball star with the Knicks.\n    ","prefix":"wn yards through tree giveaways.","suffix":"Photo\n    \n            \n\n\n      "})
+    let text = range.toString()
+    assert.equal(range.toString(), "“A really important tree is about to hit the ground,” Mayor Bloomberg declared in St. Nicholas Park on Tuesday morning, before he lifted a shovel and planted an 11-year-old pin oak on a patch of lawn. He was helped by Representative Charles B. Rangel and other elected officials, as well as Carmelo Anthony, the Brooklyn-born basketball star with the Knicks.\n\n")
+  })
+})

--- a/test/fixtures/bug.html
+++ b/test/fixtures/bug.html
@@ -1,0 +1,58 @@
+<p class="story-body-text story-content" data-para-count="488" data-total-count="4326" id="story-continues-4">The Million Trees campaign, which is a year ahead of schedule, is a partnership between New York City and a nonprofit agency
+    founded by
+    <person idsrc="nyt-per" value="movies::::::http://movies.nytimes.com/person/102748/Bette-Midler|||automobiles,business,college,dining,education,fashion,garden,giving,health,international,jobs,magazine,multimedia,national,nyregion,obituaries,politics,realestate,science,sports,style,technology,theater,travel,weekinreview:::More articles about Bette Midler.:::http://topics.nytimes.com/top/reference/timestopics/people/m/bette_midler/index.html">
+        <alt-code value="Midler, Bette" idsrc="nyt-per"></alt-code>Bette Midler</person>, the
+    <a title="Web site" href="http://www.nyrp.org/">New York Restoration Project</a>. The city is overseeing new trees on streets and in parks, which will make up most of
+    the plantings. The Restoration Project, meanwhile, is focusing its efforts on libraries, churches, cemeteries and housing
+    projects, while encouraging New Yorkers to plant trees in their own yards through tree giveaways.</p>
+<p class="story-body-text story-content"
+    data-para-count="362" data-total-count="4688">“A really important tree is about to hit the ground,” Mayor Bloomberg declared in St. Nicholas Park on Tuesday morning, before
+    he lifted a shovel and planted an 11-year-old pin oak on a patch of lawn. He was helped by Representative
+    <person idsrc="nyt-per"
+        value="automobiles,business,college,dealbook,dining,education,fashion,garden,giving,health,jobs,magazine,movies,multimedia,nyregion,obituaries,realestate,science,sports,style,technology,theater,travel,us,washington,weekinreview,world:::More articles about Charles B. Rangel.:::http://topics.nytimes.com/top/reference/timestopics/people/r/charles_b_rangel/index.html">
+        <alt-code value="Rangel, Charles B" idsrc="nyt-per"></alt-code>Charles B. Rangel</person> and other elected officials, as well as
+    <person idsrc="nyt-per" value="automobiles,business,college,dealbook,dining,education,fashion,garden,giving,health,jobs,magazine,movies,multimedia,nyregion,obituaries,realestate,science,sports,style,technology,theater,travel,us,washington,weekinreview,world:::More articles about Carmelo Anthony.:::http://topics.nytimes.com/top/reference/timestopics/people/a/carmelo_anthony/index.html">
+        <alt-code value="Anthony, Carmelo" idsrc="nyt-per"></alt-code>Carmelo Anthony</person>, the
+    <location location-code="realestate:::Find Real Estate listings and community news for Brooklyn:::http://topics.nytimes.com/top/classifieds/realestate/locations/newyork/newyorkcity/brooklyn/"
+        code-source="nyt-geo">
+        <alt-code value="Brooklyn (NYC)" idsrc="nyt-geo"></alt-code>Brooklyn</location>-born basketball star with the
+    <org idsrc="nyt-org" value="sports:::Recent news and scores about the New York Knicks.:::http://topics.nytimes.com/top/news/sports/probasketball/nationalbasketballassociation/newyorkknicks/index.html">
+        <alt-code value="New York Knicks" idsrc="nyt-org"></alt-code>Knicks</org>.</p>
+<figure id="media-100000001120823" class="media photo embedded layout-large-vertical media-100000001120823"
+    data-media-action="modal" itemprop="associatedMedia" itemscope itemid="https://static01.nyt.com/images/2011/10/19/nyregion/YJUMPTREE/YJUMPTREE-popup.jpg"
+    itemtype="http://schema.org/ImageObject" aria-label="media" role="group">
+    <span class="visually-hidden">Photo</span>
+    <div class="image">
+        <img src="https://static01.nyt.com/images/2011/10/19/nyregion/YJUMPTREE/YJUMPTREE-popup.jpg" alt="" class="media-viewer-candidate"
+            data-mediaviewer-src="https://static01.nyt.com/images/2011/10/19/nyregion/YJUMPTREE/YJUMPTREE-jumbo.jpg" data-mediaviewer-caption="Mayor Michael R. Bloomberg installed this pin oak in Manhattan on Tuesday, the 500,000th tree in a city planting campaign."
+            data-mediaviewer-credit="Chester Higgins Jr./The New York Times" itemprop="url" itemid="https://static01.nyt.com/images/2011/10/19/nyregion/YJUMPTREE/YJUMPTREE-popup.jpg"
+        />
+        <meta itemprop="height" content="500" />
+        <meta itemprop="width" content="335" />
+    </div>
+    <figcaption class="caption" itemprop="caption description">
+        <span class="caption-text">Mayor Michael R. Bloomberg installed this pin oak in Manhattan on Tuesday, the 500,000th tree in a city planting
+            campaign.</span>
+        <span class="credit" itemprop="copyrightHolder">
+            <span class="visually-hidden">Credit</span>
+            Chester Higgins Jr./The New York Times </span>
+    </figcaption>
+</figure>
+<p class="story-body-text story-content" data-para-count="290" data-total-count="4978">As with most initiatives under the Bloomberg administration, the tree effort has been meticulously documented. Some 120 species
+    have been planted across the city so far, with Manhattan receiving 49,045 trees (9.8 percent of the 500,000) and the
+    <location location-code="realestate:::Find Real Estate listings and community news for the Bronx:::http://topics.nytimes.com/top/classifieds/realestate/locations/newyork/newyorkcity/bronx/"
+        code-source="nyt-geo">
+        <alt-code value="Bronx (NYC)" idsrc="nyt-geo"></alt-code>Bronx</location> getting 135,626 trees, or 27.1 percent.</p>
+<p class="story-body-text story-content" data-para-count="482"
+    data-total-count="5460">To address residents’ concerns, the city has introduced a number of programs. For buckling sidewalks, for instance, the city
+    now does repairs in front of one- to three-family homes; in the past, it was the homeowner’s responsibility. Since starting
+    a repair program several years ago, the city has received 38,300 requests, and it has addressed 9,169 so far. To prevent
+    buckling in the first place, all new trees have considerably larger beds, allowing room for spreading roots.</p>
+<p class="story-body-text story-content"
+    data-para-count="179" data-total-count="5639">As for pruning, the city says it responds to all complaints about dead limbs or trees within 30 days; if the condition is
+    deemed hazardous, the work will be performed immediately.</p>
+<p class="story-body-text story-content" data-para-count="333"
+    data-total-count="5972">The parks department, with the nonprofit group
+    <a href="http://www.treesny.org/">Trees New York</a>, has stepped up its “citizen pruner” program, in which residents can become trained and certified
+    to do limited pruning of street trees. The one limitation, however, is that citizen pruners must keep their feet on the
+    ground, which prevents most work on taller trees.</p>


### PR DESCRIPTION
This is a test case from some real-world tests. This quote won't anchor, and therefore we fall back to the range package, which most of the time doesn't anchor correctly. The selector was generated with this package.